### PR TITLE
Solving problems with dependabot and the not compatible java 8 libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: weekly
       day: "friday"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "ch.qos.logback:logback-classic" # Versions up to 1.3 not support Java 8
+        versions: [">=1.4.0"]
+      - dependency-name: "org.mockito:mockito-core" # Versions up to 5 not support Java 8
+        versions: [ ">=5.0" ]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
This PR, closes #68 and fix problems with dependabot and not compatible libraries (not supported by Java 8)
I've added the necessary directives to ignore up to the last compatible version (mockito >4 and  ch.log.os 1.3)