### PR TITLE
Refactoring and solving problems in the classifier, scheduler and orchestrator packages

### DIFF
--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/classifier/EmptyInputException.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/classifier/EmptyInputException.java
@@ -1,8 +1,5 @@
 package giis.retorch.orchestration.classifier;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * The {@code EmptyInputException}  is thrown when the {@code RetorchClassifier} receives an input that is empty
  * or its invalid i.e: null, no exist directories...
@@ -10,10 +7,8 @@ import org.slf4j.LoggerFactory;
 public class EmptyInputException extends Exception {
 
     private static final long serialVersionUID = -6473170362328956807L;
-    private static final Logger logEmptyInputException = LoggerFactory.getLogger(EmptyInputException.class);
 
     public EmptyInputException(String errorMessage) {
         super(errorMessage);
-        logEmptyInputException.error(errorMessage);
     }
 }

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/classifier/ResourceSerializer.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/classifier/ResourceSerializer.java
@@ -52,8 +52,11 @@ public class ResourceSerializer {
         ElasticityModel elasModel = new ElasticityModel("elasModel" + resourceId);
         elasModel.setElasticityCost(elasticityCost);
         elasModel.setElasticity(elasticity);
+        List<String> parents = (hierarchyParent != null)
+                ? new LinkedList<>(Collections.singletonList(hierarchyParent))
+                : new LinkedList<>();
         resourcesToSerialize.put(resourceId, new Resource(resourceId,
-                new LinkedList<>(Collections.singletonList(hierarchyParent)), new LinkedList<>(), elasModel,
+                parents, new LinkedList<>(), elasModel,
                 getResourceTypeFromAnnotation(resourceType), new LinkedList<>(), "someimage"));
     }
 
@@ -66,12 +69,13 @@ public class ResourceSerializer {
         try {
             return Resource.type.valueOf(type);
         } catch (IllegalArgumentException e) {
-            return Resource.type.LOGICAL; // Default to LOGICAL if type is not recognized
+            logSerializer.warn("Unknown resource type '{}', defaulting to LOGICAL", type);
+            return Resource.type.LOGICAL;
         }
     }
 
     /**
-     * Support method that adds a resource to the dictionary to serialize without hierarchy  parent
+     * Support method that adds a resource to the dictionary to serialize without hierarchy parent
      *
      * @param elasticity     Integer with the resource elasticity
      * @param elasticityCost Double with the elasticity cost
@@ -79,11 +83,7 @@ public class ResourceSerializer {
      * @param resourceId     String with the resource ID
      */
     public void addResourceToSerialize(String resourceId, double elasticityCost, int elasticity, String resourceType) {
-        ElasticityModel elasModel = new ElasticityModel("elasModel" + resourceId);
-        elasModel.setElasticityCost(elasticityCost);
-        elasModel.setElasticity(elasticity);
-        resourcesToSerialize.put(resourceId, new Resource(resourceId, new LinkedList<>(), new LinkedList<>(),
-                elasModel, getResourceTypeFromAnnotation(resourceType), new LinkedList<>(), "someImage"));
+        addResourceToSerialize(resourceId, elasticityCost, elasticity, resourceType, null);
     }
 
     /**
@@ -103,14 +103,9 @@ public class ResourceSerializer {
      * @param filePath the path of the file to write to
      * @param output   the string to write to the file
      */
-    private void writeSerializationToFile(String filePath, String output) {
-        try {
-            Path path = Paths.get(filePath);
-            byte[] strToBytes = output.getBytes();
-            Files.write(path, strToBytes);
-        } catch (IOException e) {
-            logSerializer.error("The path {} doesn't exist", filePath);
-        }
+    private void writeSerializationToFile(String filePath, String output) throws IOException {
+        Path path = Paths.get(filePath);
+        Files.write(path, output.getBytes());
     }
 
     /**

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/classifier/RetorchClassifier.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/classifier/RetorchClassifier.java
@@ -28,9 +28,8 @@ public class RetorchClassifier {
 
     private static final String CHORUS_ATTRIBUTES = " is not present";
     private static final String NO_EXIST = " doesn't exist";
+    private static final String JACOCO_INIT_METHOD = "$jacocoInit";
     private final ResourceSerializer deserializer; //Serializer employed to deserialize the resources info
-
-    private Map<String, Resource> listAllResources;
 
     /**
      * Empty constructor used to validate RETORCH in the test case
@@ -54,6 +53,7 @@ public class RetorchClassifier {
         }
         URL resourceURL = classLoader.getResource(packageName.replace('.', '/'));
         if (resourceURL == null) {
+            log.error("Package {} not found on classpath.", packageName);
             throw new EmptyInputException("Package " + packageName + " not found on classpath.");
         }
         URI uri = resourceURL.toURI();
@@ -103,22 +103,22 @@ public class RetorchClassifier {
      */
     public System getSystemFromPackage(String systemName, String packageName) throws EmptyInputException,
             IOException, ClassNotFoundException, URISyntaxException {
-        this.listAllResources= new HashMap<>();
-        for (Resource res:deserializer.deserializeResources(systemName).values()){
-            if (resourceChecker(res)){
-                this.listAllResources.put(res.getResourceID(),res);
+        Map<String, Resource> validatedResources = new HashMap<>();
+        for (Resource res : deserializer.deserializeResources(systemName).values()) {
+            if (resourceChecker(res)) {
+                validatedResources.put(res.getResourceID(), res);
             }
         }
         System systemRetorch = new System(systemName);
         File directory = getPackageSourceDirectory(packageName);
         List<Class<?>> listClassesPackage = findClasses(directory, packageName);
         for (Class<?> currentClass : listClassesPackage) {
-            System temporalSystem = getSystemFromClass(systemName, currentClass);
+            System temporalSystem = getSystemFromClass(systemName, currentClass, validatedResources);
             addUniqueResources(systemRetorch, temporalSystem);
             systemRetorch.addListTestCases(temporalSystem.getTestCases());
         }
         sortSystemClass(systemRetorch);
-        return checkSystemClass(systemRetorch);
+        return checkSystemClass(systemRetorch, validatedResources);
     }
 
     private void addUniqueResources(System systemRetorch, System temporalSystem) {
@@ -143,20 +143,27 @@ public class RetorchClassifier {
      */
     public System getSystemFromClass(String systemName, Class<?> testCaseClass) throws EmptyInputException,
             IOException {
-        this.listAllResources = deserializer.deserializeResources(systemName);
+        Map<String, Resource> resourceMap = deserializer.deserializeResources(systemName);
+        return getSystemFromClass(systemName, testCaseClass, resourceMap);
+    }
+
+    private System getSystemFromClass(String systemName, Class<?> testCaseClass, Map<String, Resource> resourceMap)
+            throws EmptyInputException {
         System systemRetorch = new System(systemName);
         List<Method> listMethods = this.getClassMethods(testCaseClass);
-        systemRetorch.addListOfResources(new ArrayList<>(listAllResources.values()));
+        systemRetorch.addListOfResources(new ArrayList<>(resourceMap.values()));
         for (Method m : listMethods) {
-            TestCase testCase = getTestCasesFromMethod(m, testCaseClass);
+            TestCase testCase = getTestCasesFromMethod(m, testCaseClass, resourceMap);
             if (validateTestCase(testCase)) {
                 systemRetorch.addTestCase(testCase);
             }
         }
-        if (listMethods.isEmpty())
+        if (listMethods.isEmpty()) {
+            log.error("No annotated methods found in class {}", testCaseClass.getName());
             throw new EmptyInputException(String.format("No annotated methods found in class %s",
                     testCaseClass.getName()));
-        return checkSystemClass(systemRetorch);
+        }
+        return checkSystemClass(systemRetorch, resourceMap);
     }
 
     /**
@@ -182,11 +189,12 @@ public class RetorchClassifier {
      * the access modes, for later create a new TestCaseClass object with the method name and its access modes*
      * @param currentClass  Class that belongs the method
      * @param currentMethod Test case Method
+     * @param resourceMap   Map of available resources
      */
-    public TestCase getTestCasesFromMethod(Method currentMethod, Class<?> currentClass) {
+    public TestCase getTestCasesFromMethod(Method currentMethod, Class<?> currentClass,
+                                           Map<String, Resource> resourceMap) {
         String methodName = currentMethod.getName();
-        // Directly assign the result of getAccessModesFromMethod to listAccessModesMethod
-        List<AccessMode> listAccessModesMethod = this.getAccessModesFromMethod(currentMethod);
+        List<AccessMode> listAccessModesMethod = this.getAccessModesFromMethod(currentMethod, resourceMap);
         TestCase newTestCase = new TestCase(methodName, currentClass);
         newTestCase.setAccessMode(listAccessModesMethod);
         return newTestCase;
@@ -198,9 +206,10 @@ public class RetorchClassifier {
      * it, checks if the resource and Access mode RETORCH annotations are present, retrieving a list with them.Then
      * creates
      * the accessModes with all the information retrieved from the annotations ( resource,elasticity,sharing...)
-     * @param testMethod Method to retrieve the annotations.
+     * @param testMethod  Method to retrieve the annotations.
+     * @param resourceMap Map of available resources
      */
-    public List<AccessMode> getAccessModesFromMethod(Method testMethod) {
+    public List<AccessMode> getAccessModesFromMethod(Method testMethod, Map<String, Resource> resourceMap) {
         List<AccessMode> listAccessModes = new ArrayList<>(); // Use ArrayList instead of LinkedList for better
 
         List<giis.retorch.annotations.AccessMode> listAccessModesTag = new ArrayList<>();  // random access performance
@@ -214,13 +223,15 @@ public class RetorchClassifier {
            }
         for (giis.retorch.annotations.AccessMode accessTag : listAccessModesTag) {
             if (this.accessModeTagChecker(accessTag, testMethod.getName())) {
-                AccessMode currentAccessMode = new AccessMode();
-                currentAccessMode.setConcurrency(accessTag.concurrency());
-                Resource requiredResource = getRequiredResource(accessTag.resID());
-                currentAccessMode.setResource(requiredResource);
-                currentAccessMode.setSharing(accessTag.sharing());
-                currentAccessMode.setType(new AccessModeTypes(accessTag.accessMode()));
-                listAccessModes.add(currentAccessMode);
+                Optional<Resource> requiredResource = getRequiredResource(accessTag.resID(), resourceMap);
+                if (requiredResource.isPresent()) {
+                    AccessMode currentAccessMode = new AccessMode();
+                    currentAccessMode.setConcurrency(accessTag.concurrency());
+                    currentAccessMode.setResource(requiredResource.get());
+                    currentAccessMode.setSharing(accessTag.sharing());
+                    currentAccessMode.setType(new AccessModeTypes(accessTag.accessMode()));
+                    listAccessModes.add(currentAccessMode);
+                }
             }
         }
         return listAccessModes;
@@ -229,14 +240,12 @@ public class RetorchClassifier {
     /**
      * Support method that checks the resources annotated with the access mode
      */
-    public Resource getRequiredResource(String idResource) {
-        String message;
-        if (listAllResources.containsKey(idResource)) {
-            return listAllResources.get(idResource);
+    public Optional<Resource> getRequiredResource(String idResource, Map<String, Resource> resourceMap) {
+        if (resourceMap.containsKey(idResource)) {
+            return Optional.of(resourceMap.get(idResource));
         } else {
-            message=String.format("The resource %s is not tagged", idResource);
-            log.info(message);
-            return new Resource("Resource Not valid");
+            log.error("The resource {} is not tagged", idResource);
+            return Optional.empty();
         }
     }
 
@@ -248,10 +257,21 @@ public class RetorchClassifier {
     public List<Method> getClassMethods(Class<?> testClass) {
         List<Method> methods = Arrays.stream(testClass.getDeclaredMethods())
                 .sorted(Comparator.comparing(Method::toString)) // Sort methods
-                .filter(meth -> !meth.getName().equals("$jacocoInit")) // Filter out methods with name "$jacocoInit"
+                .filter(meth -> !meth.getName().equals(JACOCO_INIT_METHOD)) // Filter out JaCoCo instrumentation methods
                 .collect(Collectors.toList());// Collect results to a list
         methods.forEach(meth -> log.info("The method name its : {}", meth.getName()));
         return methods;
+    }
+
+    private boolean logAndReturn(List<String> messages, String context) {
+        if (messages.isEmpty()) {
+            log.debug("No errors produced during the {}", context);
+        } else {
+            for (String message : messages) {
+                log.error(message);
+            }
+        }
+        return messages.isEmpty();
     }
 
     /**
@@ -277,10 +297,7 @@ public class RetorchClassifier {
             listMessages.add(String.format("There are more than 2 HierarchyParents in resource %s and is mandatory provide " +
                     "only one ",resource.getResourceID()));
         }
-        if(listMessages.isEmpty()) log.debug("No errors produced during the Resource checking");
-        else{for (String message : listMessages) {log.error(message);}}
-
-        return elasticityChecker(resource) && listMessages.isEmpty();
+        return elasticityChecker(resource) && logAndReturn(listMessages, "Resource checking");
     }
 
     /**
@@ -314,10 +331,7 @@ public class RetorchClassifier {
                 listMessages.add(String.format("The Specified Elasticity Cost in resource %s is not valid", resource.getResourceID()));
             }
         }
-        if(listMessages.isEmpty()) log.debug("No errors produced during the ElasticityMode checking");
-        else{for (String message : listMessages) {log.error(message);}}
-
-        return listMessages.isEmpty();
+        return logAndReturn(listMessages, "ElasticityModel checking");
     }
 
     /**
@@ -336,13 +350,7 @@ public class RetorchClassifier {
         }
         checkAccessModeType(accessModeTag, methodName, listMessages);
 
-        if (listMessages.isEmpty()) {
-            log.debug("No errors produced during the AccessModeTag checking");
-        } else {
-            for (String message: listMessages) {log.error(message);}
-        }
-
-        return listMessages.isEmpty();
+        return logAndReturn(listMessages, "AccessModeTag checking");
     }
 
     private void checkConcurrency(giis.retorch.annotations.AccessMode accessModeTag, String methodName, List<String> listMessages) {
@@ -369,10 +377,11 @@ public class RetorchClassifier {
     /**
      * Support method that validates the System provided as parameter. It checks  that the replaceable resources exists
      * @param systemToCheck System to check tag
+     * @param resourceMap   Map of available resources
      */
-    private System checkSystemClass(System systemToCheck) {
+    private System checkSystemClass(System systemToCheck, Map<String, Resource> resourceMap) {
         System systemOutput = new System(systemToCheck.getName());
-        List<String> idResourcesList = listAllResources.values().stream()
+        List<String> idResourcesList = resourceMap.values().stream()
                 .map(Resource::getResourceID).collect(Collectors.toList());
         systemToCheck.getResources().stream()
                 .filter(res -> idResourcesList.containsAll(res.getReplaceable()))

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/model/Resource.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/model/Resource.java
@@ -1,8 +1,6 @@
 package giis.retorch.orchestration.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
@@ -18,8 +16,6 @@ import java.util.List;
 public class Resource {
 
     public enum type {PHYSICAL, LOGICAL, COMPUTATIONAL}
-
-    private final Logger logResourceClass = LoggerFactory.getLogger(Resource.class);
 
     Marker errorMarker = MarkerFactory.getMarker("Error");
     private String resourceID;
@@ -91,13 +87,9 @@ public class Resource {
 
     @Override
     public boolean equals(Object obj) {
-        String message;
         if (obj == null || !obj.getClass().equals(this.getClass())) return false;
         Resource resClass = (Resource) obj;
         if (!this.elasticityModel.equals(resClass.elasticityModel)) {
-            if (this.elasticityModel.getElasticityID().equals(resClass.elasticityModel.getElasticityID())){
-                message=String.format("The elasticityModel of the resources with the same identifier " + "%s differ", resClass.getResourceID());
-                logResourceClass.error(message);}
             return false;
         }
         if ((!containsAllReplaceableElements(this.replaceable, resClass.getReplaceable())) ||

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/orchestrator/JenkinsOrchestrator.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/orchestrator/JenkinsOrchestrator.java
@@ -29,7 +29,7 @@ public class JenkinsOrchestrator implements IRetorchOrchestrator {
     private final Properties ciConfiguration;
     private ExecutionPlan executionPlan;
     private final Map<String, Resource> listAllResources;
-    ResourceSerializer deserializer;
+    private final ResourceSerializer deserializer;
     /**
      * Default constructor, gets a list of {@code Activity} and deserialize the ResourceJSON.json and retorchCI properties
      * the files, filling the different structures that would be used by the JenkinsOrchestrator
@@ -144,7 +144,7 @@ public class JenkinsOrchestrator implements IRetorchOrchestrator {
         if (Files.exists(Paths.get(".retorch/scripts"))) {
             FileUtils.deleteDirectory(new File(".retorch/scripts"));
         }
-        ScriptGenerator scriptler = new ScriptGenerator();
+        ScriptGenerator scriptler = new ScriptGenerator(this.ciConfiguration);
         stringBuilder.append("pipeline {\n")
                 .append("  agent {label '").append(this.ciConfiguration.getProperty("agentCIName")).append("'}\n")
                 .append("  environment {\n")
@@ -248,13 +248,12 @@ public class JenkinsOrchestrator implements IRetorchOrchestrator {
      * @param tJobWithTestCases {@code TJob} to put into the
      */
     public Map<String, String> getMapWithInformation(Map<String, String> mapWithDockerImages, TJob tJobWithTestCases) {
+        String tJobNameLower = tJobWithTestCases.getIdTJob().toLowerCase(Locale.ROOT);
         Map<String, String> mapData = new HashMap<>();
-
-        mapData.put("tjob_name", tJobWithTestCases.getIdTJob().toLowerCase(Locale.ROOT));
+        mapData.put("tjob_name", tJobNameLower);
         mapData.put(TJOB_BASE_PATH, ciConfiguration.getProperty(TJOB_BASE_PATH));
         mapData.putAll(mapWithDockerImages);
-        mapData.put(APP_URL_PROPERTY,ciConfiguration.getProperty(APP_URL_PROPERTY).replace("$TJOB_NAME",tJobWithTestCases.getIdTJob().toLowerCase(Locale.ROOT)));
-
+        mapData.put(APP_URL_PROPERTY, ciConfiguration.getProperty(APP_URL_PROPERTY).replace("$TJOB_NAME", tJobNameLower));
         return mapData;
     }
 

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/orchestrator/ScriptGenerator.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/orchestrator/ScriptGenerator.java
@@ -3,7 +3,12 @@ package giis.retorch.orchestration.orchestrator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,41 +52,42 @@ public class ScriptGenerator {
     private static final Logger log = LoggerFactory.getLogger(ScriptGenerator.class);
     private final Properties ciConfiguration;
 
+    public ScriptGenerator(Properties ciConfiguration) {
+        this.ciConfiguration = ciConfiguration;
+    }
+
     public ScriptGenerator() {
-        ciConfiguration = new Properties();
+        this(loadProperties());
+    }
+
+    private static Properties loadProperties() {
+        Properties props = new Properties();
         try (InputStream input = Files.newInputStream(Paths.get(".retorch/configurations/retorchCI.properties"))) {
-            ciConfiguration.load(input);
+            props.load(input);
         } catch (IOException e) {
             log.error("Not possible to load properties file due to: {} ", e.getMessage());
         }
+        return props;
     }
 
     /**
      * This method generates all the set-up, execution and disposing scripts required to execute the {@code ExecutionPlan}
      * in the continuous integration system.
      */
-    public void generateScriptsTJob() {
-        try {
-            checkFolderExists(DIRECTORY_TJOBS_NAME);
-            Map<String, String> mapValues = new HashMap<>();
-            mapValues.put("${SUT_CONTAINER_NAME}", ciConfiguration.getProperty("sut-container-name"));
-            mapValues.put("${SUT-WAIT-HTML}", ciConfiguration.getProperty("sut-wait-html"));
-            mapValues.put("${CUSTOM_SETUP_TJOB_COMMANDS}", getCustomContent("tjob-setup"));
-            mapValues.put("${CUSTOM_TEARDOWN_TJOB_COMMANDS}", getCustomContent("tjob-teardown"));
-
-
-
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_TJOB_SETUP_TEMPLATE, OUTPUT_FILE_TJOB_SETUP);
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_TJOB_TESTEXECUTION_TEMPLATE,
-                    OUTPUT_FILE_TJOB_TESTEXECUTION);
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_TJOB_TEARDOWN_TEMPLATE, OUTPUT_FILE_TJOB_TEARDOWN);
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_WAITER_TEMPLATE, OUTPUT_FILE_WAITER);
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_WRITE_TIME_TEMPLATE, OUTPUT_FILE_WRITE_TIME);
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_SAVE_CONTAINER_LOGS, OUTPUT_FILE_CONTAINER_LOGS);
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_LOGGING, OUTPUT_FILE_LOGGING);
-        } catch (IOException e) {
-            log.error("Error while generating TJOBs scripts: {}", e.getMessage());
-        }
+    public void generateScriptsTJob() throws IOException {
+        checkFolderExists(DIRECTORY_TJOBS_NAME);
+        Map<String, String> mapValues = new HashMap<>();
+        mapValues.put("${SUT_CONTAINER_NAME}", ciConfiguration.getProperty("sut-container-name"));
+        mapValues.put("${SUT-WAIT-HTML}", ciConfiguration.getProperty("sut-wait-html"));
+        mapValues.put("${CUSTOM_SETUP_TJOB_COMMANDS}", getCustomContent("tjob-setup"));
+        mapValues.put("${CUSTOM_TEARDOWN_TJOB_COMMANDS}", getCustomContent("tjob-teardown"));
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_TJOB_SETUP_TEMPLATE, OUTPUT_FILE_TJOB_SETUP);
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_TJOB_TESTEXECUTION_TEMPLATE, OUTPUT_FILE_TJOB_TESTEXECUTION);
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_TJOB_TEARDOWN_TEMPLATE, OUTPUT_FILE_TJOB_TEARDOWN);
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_WAITER_TEMPLATE, OUTPUT_FILE_WAITER);
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_WRITE_TIME_TEMPLATE, OUTPUT_FILE_WRITE_TIME);
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_SAVE_CONTAINER_LOGS, OUTPUT_FILE_CONTAINER_LOGS);
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_LOGGING, OUTPUT_FILE_LOGGING);
     }
 
     public static void checkFolderExists(String path) throws IOException {
@@ -91,7 +97,7 @@ public class ScriptGenerator {
             Files.createDirectories(directoryPath);
             log.debug("Directory created successfully.");
         } else {
-            log.error("The directory already exists.");
+            log.debug("The directory {} already exists.", path);
         }
     }
 
@@ -134,19 +140,18 @@ public class ScriptGenerator {
      * @param values        the map with the different configuration values
      * @param outputFile    String with the location of the output file
      */
-    public void replacePlaceholderTemplate(Map<String, String> values, String inputTemplate, String outputFile) {
-        try (BufferedReader br = getFileFromResource(inputTemplate); BufferedWriter bw =
-                new BufferedWriter(new FileWriter(outputFile))) {
-            System.setProperty("line.separator", "\n");
+    public void replacePlaceholderTemplate(Map<String, String> values, String inputTemplate, String outputFile)
+            throws IOException {
+        try (BufferedReader br = getFileFromResource(inputTemplate);
+             BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(
+                     Files.newOutputStream(Paths.get(outputFile)), StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
                 StringBuilder sb = getStringBuilder(values, line);
                 bw.write(sb.toString());
-                bw.newLine();
+                bw.write("\n");
             }
             log.info("Files successfully created.");
-        } catch (IOException e) {
-            log.error("Error while writing to file: {}", e.getMessage());
         }
     }
 
@@ -168,20 +173,18 @@ public class ScriptGenerator {
     private BufferedReader getFileFromResource(String fileName) {
         ClassLoader classLoader = getClass().getClassLoader();
         InputStream in = classLoader.getResourceAsStream(fileName);
-        assert in != null;
+        if (in == null) {
+            throw new IllegalStateException("Template resource not found on classpath: " + fileName);
+        }
         return new BufferedReader(new InputStreamReader(in));
     }
 
-    public void generateScriptsCOI() {
-        try {
-            checkFolderExists(DIRECTORY_COI_NAME);
-            Map<String, String> mapValues = new HashMap<>();
-            mapValues.put("${CUSTOM_SETUP_COI_COMMANDS}", getCustomContent("coi-setup"));
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_COI_SETUP_TEMPLATE, OUTPUT_FILE_COI_SETUP);
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_COI_TEARDOWN_TEMPLATE, OUTPUT_FILE_COI_TEARDOWN);
-            replacePlaceholderTemplate(mapValues, INPUT_FILE_SAVE_ALL_TJOBS_TEMPLATE, OUTPUT_FILE_SAVE_ALL_TJOBS);
-        } catch (IOException e) {
-            log.error("Error while generating COI scripts: {}", e.getMessage());
-        }
+    public void generateScriptsCOI() throws IOException {
+        checkFolderExists(DIRECTORY_COI_NAME);
+        Map<String, String> mapValues = new HashMap<>();
+        mapValues.put("${CUSTOM_SETUP_COI_COMMANDS}", getCustomContent("coi-setup"));
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_COI_SETUP_TEMPLATE, OUTPUT_FILE_COI_SETUP);
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_COI_TEARDOWN_TEMPLATE, OUTPUT_FILE_COI_TEARDOWN);
+        replacePlaceholderTemplate(mapValues, INPUT_FILE_SAVE_ALL_TJOBS_TEMPLATE, OUTPUT_FILE_SAVE_ALL_TJOBS);
     }
 }

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/scheduler/RetorchAggregator.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/scheduler/RetorchAggregator.java
@@ -16,15 +16,16 @@ import java.util.stream.Collectors;
 public class RetorchAggregator {
 
     private static final Logger logRetorchAggregator = LoggerFactory.getLogger(RetorchAggregator.class);
-    final Marker errorMarker = MarkerFactory.getMarker("ErrorMarker");
+    private final Marker errorMarker = MarkerFactory.getMarker("ErrorMarker");
     private final HashMap<String, TGroup> mapTGroups;
     private final System aggregatorSystem;
     private Map<String, Resource> mapAvailableResources;
 
     public RetorchAggregator(System system) throws NotValidSystemException, IOException {
-        this.aggregatorSystem = validateSystem(system) ? system : new System("EmptySystem ERROR");
+        boolean isValid = validateSystem(system);
+        this.aggregatorSystem = isValid ? system : new System("EmptySystem ERROR");
         this.mapTGroups = new HashMap<>();
-        if (validateSystem(system)) {
+        if (isValid) {
             ResourceSerializer serializer = new ResourceSerializer();
             this.mapAvailableResources = serializer.deserializeResources(system.getName());
         }
@@ -42,8 +43,8 @@ public class RetorchAggregator {
      */
 
     public boolean validateSystem(System systemToCheck) throws NotValidSystemException {
-        boolean areResourcesEmpty = true;
-        boolean areTestCasesEmpty = true;
+        boolean hasResources = true;
+        boolean hasTestCases = true;
         boolean areAllResourcesRequiredByTestCase;
         boolean areAllResourcesFullFill;
         boolean thereAreNoDuplicates = true;
@@ -52,13 +53,13 @@ public class RetorchAggregator {
             message=String.format("The number of resources in the system %s is zero",
                     systemToCheck.getName());
             logRetorchAggregator.error(message);
-            areResourcesEmpty = false;
+            hasResources = false;
         }
         if (systemToCheck.getTestCases().isEmpty()) {
             message=String.format("The number of test cases in the system %s is zero",
                     systemToCheck.getName());
             logRetorchAggregator.error(message);
-            areTestCasesEmpty = false;
+            hasTestCases = false;
         }
         Set<String> duplicateTestCases = findDuplicates(systemToCheck.getTestCases());
         if (!duplicateTestCases.isEmpty()) {
@@ -70,7 +71,7 @@ public class RetorchAggregator {
         areAllResourcesRequiredByTestCase = isRequiredByATestCase(systemToCheck);
         areAllResourcesFullFill = isAllTestCasesFullFill(systemToCheck);
 
-        return thereAreNoDuplicates && areResourcesEmpty && areAllResourcesFullFill && areTestCasesEmpty && areAllResourcesRequiredByTestCase;
+        return thereAreNoDuplicates && hasResources && areAllResourcesFullFill && hasTestCases && areAllResourcesRequiredByTestCase;
     }
 
     /**
@@ -94,33 +95,18 @@ public class RetorchAggregator {
      * @param systemToCheck System on which there are the resources and test cases to validate
      */
     private boolean isRequiredByATestCase(System systemToCheck) {
-        String message;
-
-        // Get all resources in the system
-        List<String> resourcesSystem =
-                systemToCheck.getResources().stream().map(Resource::getResourceID).collect(Collectors.toList());
-        // Iterate over all resources
-        for (String resource : resourcesSystem) {
-            // Assume the resource is not required by any test case
-            boolean resourceRequired = false;
-            // Iterate over all test cases
-            for (TestCase testCase : systemToCheck.getTestCases()) {
-                // Get all resources required by the test case
-                List<String> resourcesAccessMode =
-                        testCase.getAccessMode().stream().map(AccessMode::getResource).map(Resource::getResourceID).collect(Collectors.toList());
-                // If the test case requires the resource, set resourceRequired to true and break out of the loop
-                if (resourcesAccessMode.contains(resource)) {
-                    resourceRequired = true;
-                    break;
-                }
-            }
-            if (!resourceRequired) { // If the resource is not required by any test case, log an error and return false
-                message=String.format("Resource %s not required by any test case", resource);
-                logRetorchAggregator.error(message);
+        Set<String> requiredResourceIds = systemToCheck.getTestCases().stream()
+                .flatMap(tc -> tc.getAccessMode().stream())
+                .map(am -> am.getResource().getResourceID())
+                .collect(Collectors.toSet());
+        for (Resource resource : systemToCheck.getResources()) {
+            if (!requiredResourceIds.contains(resource.getResourceID())) {
+                logRetorchAggregator.error("Resource {} not required by any test case",
+                        resource.getResourceID());
                 return false;
             }
         }
-        return true; // If all resources are required by at least one test case, return true
+        return true;
     }
 
     /**

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/scheduler/RetorchScheduler.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/scheduler/RetorchScheduler.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class RetorchScheduler {
 
     private static final Logger logRetorchScheduler = LoggerFactory.getLogger(RetorchScheduler.class);
+    private static final String PRIOR_SCH_TJOB_PREFIX = "TJobPriorSch";
     private final List<TGroup> listTGroups;
     private LinkedList<TJob> listTJobs;
     private List<Activity> activityEntities;
@@ -66,12 +67,12 @@ public class RetorchScheduler {
         TJob currentTJob;
         int numberTJob=0;
         for (TGroup tGroup : this.listTGroups) {
-            currentTJob = new TJob("TJobPriorSch"+ numberTJob,0,tGroup.getTGroupResources());
+            currentTJob = new TJob(PRIOR_SCH_TJOB_PREFIX + numberTJob, 0, tGroup.getTGroupResources());
             intelligentScheduling(currentTJob, tGroup);
             if (!currentTJob.getListTestCases().isEmpty()){
                 this.listTJobs.add(currentTJob);
             }
-            numberTJob+=1;
+            numberTJob++;
         }
     }
 
@@ -79,11 +80,16 @@ public class RetorchScheduler {
      * Support method that get all {@code Resource}s from the list of {@code TJob}s
      */
     public List<Resource> getAllResources() {
-        LinkedList<Resource> listResourcesAvailable = new LinkedList<>();
+        Set<String> seenIds = new LinkedHashSet<>();
+        List<Resource> listResourcesAvailable = new LinkedList<>();
         for (TJob tJob : this.listTJobs) {
-            for (Resource res : tJob.getListResourceClasses())
-                if (!listResourcesAvailable.contains(res))
-                    for (int i = 0; i < res.getElasticityModel().getElasticity(); i++) listResourcesAvailable.add(res);
+            for (Resource res : tJob.getListResourceClasses()) {
+                if (seenIds.add(res.getResourceID())) {
+                    for (int i = 0; i < res.getElasticityModel().getElasticity(); i++) {
+                        listResourcesAvailable.add(res);
+                    }
+                }
+            }
         }
         return listResourcesAvailable;
     }
@@ -110,12 +116,10 @@ public class RetorchScheduler {
             }
             currentTime++;
         }
-        List<Activity> output;
-        output = new LinkedList<>();
+        List<Activity> output = new LinkedList<>();
         for (Map.Entry<Integer, List<Activity>> entry : mapActivities.entrySet()) {
             output.addAll(entry.getValue());
         }
-
         return output;
     }
 

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/scheduler/ScheduleStruct.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/scheduler/ScheduleStruct.java
@@ -3,6 +3,7 @@ package giis.retorch.orchestration.scheduler;
 import giis.retorch.orchestration.model.Resource;
 import giis.retorch.orchestration.model.TJob;
 
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -38,16 +39,14 @@ public class ScheduleStruct {
         }
     }
 
-    public void removeListResources(List<Resource> elementsToDelete, List<Resource> listToBeDeleted) {
-        for (Resource resToBeDeleted : elementsToDelete) {
-            int i = 0;
-            boolean isDeleted = false;
-            while (i < listToBeDeleted.size() && !isDeleted) {
-                if (listToBeDeleted.get(i).equals(resToBeDeleted)) {
-                    listToBeDeleted.remove(i);
-                    isDeleted = true;
+    public void removeListResources(List<Resource> resourcesToConsume, List<Resource> availableResources) {
+        for (Resource toRemove : resourcesToConsume) {
+            Iterator<Resource> it = availableResources.iterator();
+            while (it.hasNext()) {
+                if (it.next().equals(toRemove)) {
+                    it.remove();
+                    break;
                 }
-                i++;
             }
         }
     }

--- a/retorch-orchestration/src/test/java/giis/retorch/orchestration/SchedulerTests.java
+++ b/retorch-orchestration/src/test/java/giis/retorch/orchestration/SchedulerTests.java
@@ -80,7 +80,7 @@ public class SchedulerTests {
         List<LoggingEvent> listEvents = argument.getAllValues();
         List<String> listMessages = listEvents.stream().map(LoggingEvent::getMessage).collect(Collectors.toList());
         //Check that the omitted AccessMode is detected and the omission of attributes in the accessMode
-        assertEquals(4, listMessages.size());
+        assertEquals(2, listMessages.size());
         assertEquals("The number of resources in the system EmptySystem is zero", listMessages.get(0));
         assertEquals("The number of test cases in the system EmptySystem is zero", listMessages.get(1));
     }


### PR DESCRIPTION
This PR refactors three core packages of the orchestrator component, reducing complexity, improving exception propagation, and improving the logging system.

Changes by Package

**Classifier**

- Removed the shared mutable listAllResources field; methods now manage and pass local maps.

- getRequiredResource now returns Optional<Resource> and handles the missing Resources by logging an error, instead of returning an empty object.

- Propagated IOException in writeSerializationToFile rather than managing and logging it.

- Deduplicated logic by extracting a logAndReturn helper and reducing the addResourceToSerialize.

**Scheduler**

- Optimized time complexity: replaced index-based List.remove with Iterator.remove (O(n²) to O(n)) and LinkedList.contains with Set lookups (O(n) to O(1)).

- Eliminated a triple-nested loop in isRequiredByATestCase by calculating required resource ids.

- Creating and catching validateSystem() result in the constructor, to avoid creating it every time.

- renamed variables to improve code understandability (e.g., areResourcesEmpty to hasResources).

**Orchestrator**

- Using cross-platform separators to avoid problems when the code is pull-pushed.

- Propagated IOException in script and pipeline generators, instead of logging and handling locally.

- Improved the logging of the  NullPointerExceptions during the resource loading, through an explicit IllegaIllegalStateException.

- Optimized ScriptGenerator to load properties a single time.