### PR TITLE
Creating a tool CLI to generate the orchestration scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ org.sonarlint.eclipse.core.prefs
 # Files created by the orchestration generator
 /retorch-orchestration/.retorch/envfiles/
 /retorch-orchestration/.retorch/scripts/
+/retorch-orchestration/dependency-reduced-pom.xml

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ suite.
   to the `pom.xml` of your SUT.
 - Add the annotations to the test classes as indicated below.
 - Configure the E2E test suite as indicated below.
-- Execute the orchestration generator and generate the pipelining-scripting code.
+- Run the orchestration generator standalone JAR to generate the pipelining-scripting code.
 - Commit and push the generated files to Git.
 
 ## RETORCH Annotations
@@ -279,58 +279,46 @@ Once created the different properties and configuration files, the single module
 
 ### Executing the Orchestration generator
 
-Once all the files created and the `docker-compose.yml` is prepared, to execute the generator we only need to
-instantiate the `giis.retorch.orchestration.generator.OrchestrationGenerator` object and call its
-`generateJenkinsfile()` method.
-To instantiate this class, first we need to include the appropriate dependency to the `pom.xml` file by adding:
+Once all the files are created and the `docker-compose.yml` is prepared, follow these steps from the
+**root of the SUT project** (the same directory that contains `.retorch/`).
 
-```yaml
-<dependency>
-<groupId>io.github.giis-uniovi</groupId>
-<artifactId>retorch-orchestration</artifactId>
-<version><!--SET HERE THE DESIRED VERSION--></version>
-</dependency>
+#### Step 1 — Compile the test classes and copy dependencies
+
+The generator loads the annotated test classes at runtime using the Java ClassLoader, so they must be compiled
+and their transitive dependencies must be available before running the JAR.
+Run the following Maven command from the project root:
+
+```bash
+mvn test-compile dependency:copy-dependencies -DincludeScope=test
 ```
 
-The calling of this class must be done in the same package of the annotated E2E test cases, in order to be capable to
-access to the generated java classes through the Java ClassLoader and extract the RETORCH `@AccessMode` annotations. The
-test class can be created using the following template, tuning it as required:
+This compiles the test sources into `target/` and copies all test-scoped dependency JARs into
+`target/dependency/` (or the equivalent subdirectory if your project overrides `outputDirectory`).
 
-```java
-package com.sutexample.functional; // TO-DO Adjust the package name
+#### Step 2 — Run the standalone JAR
 
-import giis.retorch.orchestration.classifier.EmptyInputException;
-import giis.retorch.orchestration.generator.OrchestrationGenerator;
-import giis.retorch.orchestration.orchestrator.NoFinalActivitiesException;
-import giis.retorch.orchestration.scheduler.NoTGroupsInTheSchedulerException;
-import giis.retorch.orchestration.scheduler.NotValidSystemException;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-
-@Disabled("Exclude to execute this class when pushing the SUT")
-class RetorchGenerateJenkinfileTest {
-    @Test
-    void testGenerateJenkinsfile() throws NoFinalActivitiesException, NoTGroupsInTheSchedulerException, EmptyInputException, IOException, URISyntaxException, NotValidSystemException, ClassNotFoundException {
-        OrchestrationGenerator orch = new OrchestrationGenerator();
-        orch.generateJenkinsfile("com.sutexample.functional.tests", "sutexample", "./"); // TO-DO adjust the rootPackageNameTests,systemName and jenkinsFilePath parameters 
-    }
-}
+```bash
+java -jar retorch-orchestration-<version>-standalone.jar <rootPackageNameTests> <systemName> <jenkinsFilePath>
 ```
 
-The call of the `generateJenkinsfile` method must be done with the following 3 parameters as arguments:
+The JAR is available in [Maven Central](https://central.sonatype.com/artifact/io.github.giis-uniovi/retorch-orchestration)
+with the `standalone` classifier. The three arguments are:
 
-- `rootPackageNameTests`: String that specifies the root package name where tests are located (
-  `com.sutexample.functional.tests` in the snippet).
-- `systemName`: String that specifies the system name, must correspond with the name used in
-  the [Resources JSON file](#create-the-resource-json-file) (`sutexample` in the snippet).
-- `jenkinsFilePath`: String with the location where the `Jenkinsfile` will be created, it must be the project root (`./`
-  in the snippet).
+- `rootPackageNameTests`: root package where the annotated E2E test classes are located
+  (e.g. `com.sutexample.functional.tests`).
+- `systemName`: system name that must match the name used in
+  the [Resources JSON file](#create-the-resource-json-file) (e.g. `sutexample`).
+- `jenkinsFilePath`: directory path where the `Jenkinsfile` will be written (e.g. `./` for the project root).
 
-For example, in the [FullTeaching test suite](https://github.com/giis-uniovi/retorch-st-fullteaching) this test class,
-namely `RetorchGenerateJenkinfileTest.java` is available into the `com.fullteaching.e2e.no_elastest.functional.test`
+For example, for the [FullTeaching test suite](https://github.com/giis-uniovi/retorch-st-fullteaching):
+
+```bash
+mvn test-compile dependency:copy-dependencies -DincludeScope=test
+java -jar retorch-orchestration-<version>-standalone.jar \
+  com.fullteaching.e2e.no_elastest.functional.test \
+  FullTeaching \
+  ./
+```
 
 ### RETORCH Orchestration generator outputs
 

--- a/retorch-orchestration/pom.xml
+++ b/retorch-orchestration/pom.xml
@@ -32,6 +32,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -103,6 +104,40 @@
 					<!-- Avoids Jenkins slave fail in linux and openjdk: https://stackoverflow.com/questions/23260057/the-forked-vm-terminated-without-saying-properly-goodbye-vm-crash-or-system-exi/53070605 -->
 					<useSystemClassLoader>false</useSystemClassLoader>
 				</configuration>
+			</plugin>
+
+		<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.5.3</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadedArtifactAttached>true</shadedArtifactAttached>
+							<shadedClassifierName>standalone</shadedClassifierName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>giis.retorch.orchestration.main.RetorchMain</mainClass>
+								</transformer>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 		</plugins>

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/classifier/RetorchClassifier.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/classifier/RetorchClassifier.java
@@ -80,7 +80,8 @@ public class RetorchClassifier {
                 if (file.isDirectory()) {
                     classes.addAll(findClasses(file, packageName + "." + file.getName()));
                 } else if (file.getName().endsWith(".class") && !file.getName().contains("$")) {
-                    classes.add(Class.forName(packageName + '.' + file.getName().replace(".class", "")));
+                    String className = packageName + '.' + file.getName().replace(".class", "");
+                    classes.add(Class.forName(className, false, Thread.currentThread().getContextClassLoader()));
                 }
             }
         } else {
@@ -257,6 +258,7 @@ public class RetorchClassifier {
     public List<Method> getClassMethods(Class<?> testClass) {
         List<Method> methods = Arrays.stream(testClass.getDeclaredMethods())
                 .sorted(Comparator.comparing(Method::toString)) // Sort methods
+                .filter(meth -> !meth.isSynthetic()) // Filter out compiler-generated lambdas and bridge methods
                 .filter(meth -> !meth.getName().equals(JACOCO_INIT_METHOD)) // Filter out JaCoCo instrumentation methods
                 .collect(Collectors.toList());// Collect results to a list
         methods.forEach(meth -> log.info("The method name its : {}", meth.getName()));

--- a/retorch-orchestration/src/main/java/giis/retorch/orchestration/main/RetorchMain.java
+++ b/retorch-orchestration/src/main/java/giis/retorch/orchestration/main/RetorchMain.java
@@ -1,0 +1,99 @@
+package giis.retorch.orchestration.main;
+
+import giis.retorch.orchestration.generator.OrchestrationGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CLI entry point for the RETORCH orchestration uber JAR.
+ * Usage:
+ *   java -jar retorch-orchestration-&lt;version&gt;-standalone.jar &lt;rootPackageNameTests&gt; &lt;systemName&gt; &lt;jenkinsFilePath&gt;
+ * Arguments:
+ *   rootPackageNameTests  Root package containing the annotated test classes
+ *   systemName            System name matching the &lt;systemName&gt;SystemResources.json file
+ *   jenkinsFilePath       Directory path where the Jenkinsfile will be written
+ */
+public class RetorchMain {
+
+    private static final Logger log = LoggerFactory.getLogger(RetorchMain.class);
+
+    public static void main(String[] args) {
+        if (args.length != 3) {
+            log.error("Usage: java -jar retorch-orchestration-standalone.jar <rootPackageNameTests> <systemName> <jenkinsFilePath>");
+            log.error("  rootPackageNameTests : root package containing the annotated test classes");
+            log.error("  systemName           : system name matching the <systemName>SystemResources.json file");
+            log.error("  jenkinsFilePath      : directory path where the Jenkinsfile will be written");
+            java.lang.System.exit(1);
+        }
+
+        String rootPackageNameTests = args[0];
+        String systemName = args[1];
+        String jenkinsFilePath = args[2];
+
+        try {
+            extendClasspathFromCwd();
+            OrchestrationGenerator generator = new OrchestrationGenerator();
+            generator.generateJenkinsfile(rootPackageNameTests, systemName, jenkinsFilePath);
+            log.info("Jenkinsfile and scripts generated successfully in: {}", jenkinsFilePath);
+        } catch (Exception e) {
+            log.error("Failed to generate Jenkinsfile: {}", e.getMessage(), e);
+            java.lang.System.exit(2);
+        }
+    }
+
+    /**
+     * Adds the compiled classes from the current working directory to the thread context classloader so the
+     * classifier can discover and load annotated test classes without requiring the user to manually set -cp.
+     */
+    private static void extendClasspathFromCwd() throws IOException {
+        Path targetDir = Paths.get("target").toAbsolutePath();
+        if (!Files.exists(targetDir)) {
+            return;
+        }
+        List<URL> urls = new ArrayList<>();
+        // Scan for compiled test-classes directories (handles non-standard Maven output paths)
+        try (java.util.stream.Stream<Path> walk = Files.walk(targetDir, 3, FileVisitOption.FOLLOW_LINKS)) {
+            walk.filter(p -> Files.isDirectory(p) && p.getFileName().toString().equals("test-classes"))
+                .forEach(p -> addUrl(urls, p));
+        }
+        // Add dependency JARs so that transitive dependencies (e.g. Selenium) are resolvable.
+        // Scans up to depth 2 under target/ to handle non-standard Maven output directories.
+        try (java.util.stream.Stream<Path> walk = Files.walk(targetDir, 2, FileVisitOption.FOLLOW_LINKS)) {
+            walk.filter(p -> Files.isDirectory(p) && p.getFileName().toString().equals("dependency"))
+                .forEach(depDir -> {
+                    try (java.util.stream.Stream<Path> jars = Files.walk(depDir, 1)) {
+                        jars.filter(p -> p.toString().endsWith(".jar"))
+                            .forEach(p -> addUrl(urls, p));
+                    } catch (IOException e) {
+                        log.warn("Could not scan dependency dir {}: {}", depDir, e.getMessage());
+                    }
+                });
+        }
+        if (!urls.isEmpty()) {
+            URLClassLoader loader = new URLClassLoader(
+                urls.toArray(new URL[0]),
+                Thread.currentThread().getContextClassLoader()
+            );
+            Thread.currentThread().setContextClassLoader(loader);
+        }
+    }
+
+    private static void addUrl(List<URL> urls, Path path) {
+        try {
+            urls.add(path.toUri().toURL());
+            log.debug("Added to classpath: {}", path);
+        } catch (java.net.MalformedURLException e) {
+            log.warn("Could not add {} to classpath: {}", path, e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #60 by implementing the necessary changes to convert the orchestration module (imported and used across the different demonstrators) into a CLI tool that reads the necessary configuration files from the .retorch folder and generates the Jenkinsfile, .env files, and scripts to execute the test suite in Jenkins.

The changes are the following:
- Created a new RetorchMain that serves as entrypoint for the tool.
- Configured the surefire maven plugin to generate the uber jar.
- Updated the README.md with the new instructions.
- Classifier adjustments to load the classes of the SUT to the classloader and be able to retrieve the annotations.

The tool was sucessfully executed with the following SUTs (orchestration.ps1 script is provided):
- [Fullteaching](https://github.com/giis-uniovi/retorch-st-fullteaching/tree/ft-updating-to-the-new-CLI-tool) 
- [EshopOnContainers](https://github.com/giis-uniovi/retorch-st-eShopContainers/tree/ft-aligning-with-CLI-tool)
- [PetClinic](https://github.com/giis-uniovi/retorch-st-petclinic/tree/ft-testing-RETORCH-CLI-tool)

