### PR TITLE
Combined dependency updates (2026-06-23)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       #Official documentation seems incomplete. To avoid failure when importing key: 
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     #avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
     if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
 
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
 
         <mockito.version>4.11.0</mockito.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
                     <plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.10.0</version>
+						<version>0.11.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/checkout from 6 to 7](https://github.com/giis-uniovi/retorch/pull/170)
- [Bump org.sonatype.central:central-publishing-maven-plugin from 0.10.0 to 0.11.0](https://github.com/giis-uniovi/retorch/pull/171)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.14 to 0.8.15](https://github.com/giis-uniovi/retorch/pull/168)